### PR TITLE
Bundle bats-support runtime dep as a submodule for tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "test/helpers/bats-support"]
+[submodule "bats-support"]
 	path = test/helpers/bats-support
 	url = https://github.com/ztombol/bats-support.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/helpers/bats-support"]
+	path = test/helpers/bats-support
+	url = https://github.com/ztombol/bats-support.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: bash
 before_install:
   - ./script/install-bats.sh
-  - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support
 before_script:
   - export PATH="${HOME}/.local/bin:${PATH}"
 script:

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,9 +1,7 @@
 setup() {
-  export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/.."
-  export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
 
   # Load dependencies.
-  load "${TEST_DEPS_DIR}/bats-support/load.bash"
+  load "helpers/bats-support/load"
 
   # Load library.
   load '../load'


### PR DESCRIPTION
As is known, we don't have a uniform dependency manager for shell utilities (despite attempts). So we don't want bats-support as a submodule for typical usage. (though this is an option and should be discussed separately, I think)

However, including bats-support as a submodule for use by the test suite makes sense. This eliminates the need for custom setup when cloning the repo, or knowing that bats-support needs cloned in a magic location (as a sibling). With bats-support as a submodule (included under `tests/helpers/`) a single recursive clone puts the bats-assert test repo into a runnable and green state immediately.

For a moment, I considered including bats-support using the git-subtree mechanism, which is usually a preferred alternative for 3rd party deps. Generally, I consider subtree preferable _except_ in cases where one may want to make changes to the dep itself and push back upstream from within the main repo. Since bats-assert and bats-support are both owned by "us", this makes submodules the preferred option, IMO.
