### PR TITLE
Simplify travis install of bats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: bash
-before_install:
-  - ./script/install-bats.sh
+install:
+  - git clone --depth 1 https://github.com/sstephenson/bats
   - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support
-before_script:
-  - export PATH="${HOME}/.local/bin:${PATH}"
 script:
-  - bats test
+  - ./bats/bin/bats test

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -o errexit
-set -o xtrace
-
-git clone --depth 1 https://github.com/sstephenson/bats
-cd bats && ./install.sh "${HOME}/.local" && cd .. && rm -rf bats


### PR DESCRIPTION
I don't think there's much value in running the bats install script. Rather, bats can just be cloned and executed from the clone. Indeed, this is what most of the rbenv projects do when running on travis.

This also (marginally) speeds up the test suite since there is no need to run the bats install script or remove the one-time-use clone.
